### PR TITLE
Added Egg and SimulationResult class

### DIFF
--- a/pages/taps.html
+++ b/pages/taps.html
@@ -7,6 +7,8 @@
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
   <script src="../scripts/taps.js"></script>
   <script src="../scripts/simulator.js"></script>
+  <script src="../scripts/egg.js"></script>
+  <script src="../scripts/simulation_result.js"></script>
   <!-- <script src="../scripts/tap_simulation.js"></script> -->
   <script src="../scripts/utils.js"></script>
 </head>

--- a/scripts/egg.js
+++ b/scripts/egg.js
@@ -1,0 +1,19 @@
+class Egg
+{
+	constructor(rarity, sell_value)
+	{
+		this.rarity = rarity;
+		this.sell_value = sell_value;
+		//console.log(`Created new egg with rarity ${this.rarity} and sell_value $${this.sell_value}`);
+	}
+
+	get_rarity()
+	{
+		return(this.rarity);
+	}
+
+	get_sell_value()
+	{
+		return(this.sell_value);
+	}
+}

--- a/scripts/simulation_result.js
+++ b/scripts/simulation_result.js
@@ -1,0 +1,58 @@
+class SimulationResult
+{
+	constructor(total_sauce, amount, type_of_sim)
+	{
+		this.amount = amount
+		this.total_sauce = total_sauce;
+		this.individial_sauce = total_sauce / amount;
+		this.type_of_sim = type_of_sim;
+		this.total_eggs = 0;
+
+		this.egg_list = {};
+		this.initialize();
+	}
+
+	async initialize()
+	{
+		this.rarity_list = await getRaritiesList();
+		for (let i = 0; i < this.rarity_list.length; i++)
+		{
+			this.egg_list[this.rarity_list[i] + ""] = 0;
+		}
+		//console.log(this.egg_list);
+	}
+
+	add_egg(egg)
+	{
+		this.egg_list[egg.rarity + ""]++;
+		this.total_eggs++;
+		//console.table(this.egg_list);
+	}
+
+	calculate_luck_score()
+	{
+		if (this.type_of_sim === "tap")
+		{
+			let luck_score = 1;
+			for (let i = 0; i < this.rarity_list.length; i++)
+			{
+				if (this.egg_list[this.rarity_list[i] + ""] != 0)
+				{
+					let expected_amount = this.total_sauce / this.rarity_list[i];
+					let actual_amount = this.egg_list[this.rarity_list[i] + ""];
+					luck_score *= actual_amount / expected_amount;
+				}
+			}
+			return (luck_score);
+		}
+	}
+
+	reset_list()
+	{
+		for (let i = 0; i < this.rarity_list.length; i++)
+		{
+			this.egg_list[this.rarity_list[i] + ""] = 0;
+		}
+		this.total_eggs = 0;
+	}
+}


### PR DESCRIPTION
Has not yet been implemented into the main code, but added to the taps.html
Egg literally has nothing but a constructor which sets its `rarity` and `sell_value`
SimulatorResult has:
- ⭐`amount` how many simulations as in how many powers, scrambles, frenzies, tap sessions 
- ⭐`total_sauce` how much total sauce was used (100 powers at 3m sauce each would yield 300m total_sauce)
- ⭐`type_of_sim` this is a string where we can input what type of simulation is was (tap, power, frenzy, scramble)
- `individual_sauce` this is the amount of sauce per sim (3m in the example for `total_sauce`)
- `total_eggs` this isn't used for anything but is there, just the total amount of eggs in the list
- `egg_list` this is the big boy, it's a dictionary which stores how many of each egg has been found:
`{'250': 0, '500': 0, '1000':0 ... '10000000000000':0}

As well as 3 methods:
- `add_egg(egg)` adds the Egg object passed to it
- `calculate_luck_score()` calculates luck score depending on which type it is (only "tap" has been implemented atm)
- `reset_list()` self explanatory